### PR TITLE
Adjusted variant of toast to not show Avatar

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 					noteStore.update((notes) => notes.filter((n) => n.id !== noteId));
 					toastStore.trigger({
 						message: 'Note deleted successfully',
-						background: 'variant-ghost-success'
+						background: 'variant-filled-success'
 					});
 					return;
 				}


### PR DESCRIPTION
Totally minor thing, but when watching the video at https://youtu.be/P_A0qQ7AuK8?t=933 I thought there was a bug with the Z ordering of Avatar - but it's just that the ghost allows the background to show through.  This also keeps it consistent with the new note variant.